### PR TITLE
Set xml as output format

### DIFF
--- a/Sources/SwiftPackageAcknowledgement/World.swift
+++ b/Sources/SwiftPackageAcknowledgement/World.swift
@@ -39,6 +39,7 @@ extension World {
         cocoaPodsEncoder: { cocoaPods in
             Result {
                 let encoder = PropertyListEncoder()
+                encoder.outputFormat = .xml
                 return try encoder.encode(cocoaPods)
             }
         },


### PR DESCRIPTION
The default output format is binary, which makes generated plist hard to see especially when reviewing changes in Github or looking at a file in a file editor. So, this PR set `.xml` as output format.

```swift
open class PropertyListEncoder {

    /// The output format to write the property list data in. Defaults to `.binary`.
    open var outputFormat: PropertyListSerialization.PropertyListFormat
    ...
}
```

For example, you'll see unrecognizable characters with `.binary` option.

<img width="800" alt="Screen Shot 2021-10-22 at 16 53 33" src="https://user-images.githubusercontent.com/2482478/138416732-b22c51e0-3d02-4a19-b35e-a07fa519912b.png">
