### PR TITLE
Bump 'swift-argument-parser' version to 1.0.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-          "version": "0.5.0"
+          "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
         ])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "0.0.6")),
-        .package(url: "https://github.com/teufelaudio/FoundationExtensions", .upToNextMajor(from: "0.1.6"))
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.2"),
+        .package(url: "https://github.com/teufelaudio/FoundationExtensions", from: "0.1.6")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Bump 'swift-argument-parser' version to 1.0.2 which is the latest version.
ref: https://github.com/apple/swift-argument-parser/releases/tag/1.0.2

---

The problem was that I see the following error when trying to use it with SwiftLint in `Package.swift` due to incompatible dependencies.

```
error: Dependencies could not be resolved because root depends on 'SwiftPackageAcknowledgement' 0.1.2..<1.0.0 and root depends on 'SwiftLint' 0.45.1..<1.0.0.
'SwiftPackageAcknowledgement' is incompatible with 'SwiftLint' because 'SwiftPackageAcknowledgement' depends on 'swift-argument-parser' 0.0.6..<1.0.0 and 'SwiftLint' >= 0.45.0 depends on 'swift-argument-parser' 1.0.1..<2.0.0.
```