### PR TITLE
Fix SSH repos and repos with no LICENSE

### DIFF
--- a/Sources/Models/Bridges.swift
+++ b/Sources/Models/Bridges.swift
@@ -11,7 +11,7 @@ public typealias PackageLicense = (package: ResolvedPackage, license: GitHubLice
 public func extractPackageGitHubRepositories(from spmFile: ResolvedPackageContent) -> [PackageRepository] {
     spmFile.object.pins.compactMap { spmPackage in
         guard let repository = githubRepository(from: spmPackage.repositoryURL).value else {
-            print("Ignoring project \(spmPackage.package) because we don't know how to fetch the license from it")
+            print("⚠️ Ignoring project \(spmPackage.package) because we don't know how to fetch the license from it")
             return nil
         }
 
@@ -26,7 +26,7 @@ public func fetchGithubLicenses(
 ) -> Reader<(Request, Decoder<GitHubLicense>), Publishers.Promise<[PackageLicense], GeneratePlistError>> {
     Reader { requester, decoder in
         Publishers.Promise.zip(
-            packageRepositories.map { packageRepository in
+            packageRepositories.map { packageRepository -> Publishers.Promise<PackageLicense?, GeneratePlistError> in
                 githubLicensingAPI(
                     repository: packageRepository.repository,
                     githubClientID: githubClientID,
@@ -34,8 +34,30 @@ public func fetchGithubLicenses(
                 )
                 .inject((requester, decoder))
                 .map { license in PackageLicense(package: packageRepository.package, license: license) }
+                .catch { error in
+                    // Some special errors we allow to go through, so this specific package will be removed
+                    // from the final plist, but the others will be there. Example of that: when one repo doesn't
+                    // have the LICENSES file (404), we just log to the console a message similar to the one for
+                    // wrong URLs.
+                    //
+                    // Other cases, such as 403 for example, we want to interrupt the process completely, because
+                    // we exceeded the Github API budget and none of the licenses from now on will succeed.
+                    //
+                    // These are two different levels of errors.
+
+                    if case .githubLicenseNotFound = error {
+                        print("⚠️ Ignoring project \(packageRepository.package.package) becuse we failed to download the LICENSE from github. Error: \(error)")
+
+                        // Return a nil PackageLicense for now, we filter them out in the last step (outside the Promise.zip)
+                        return .init(value: nil)
+                    }
+                    return .init(error: error)
+                }
             }
-        )
+        ).map { arrayOfOptionalPackages in
+            // Remove nil packages, that felt in the case of "soft" error (see comments above)
+            arrayOfOptionalPackages.compactMap(identity)
+        }
     }
 }
 

--- a/Sources/Models/GeneratePlistError.swift
+++ b/Sources/Models/GeneratePlistError.swift
@@ -11,6 +11,8 @@ public enum GeneratePlistError: Error {
     case invalidLicenseMetadataURL
     case unknownRepository
     case githubAPIURLError(URLError)
+    case githubLicenseNotFound
+    case githubAPIBudgetExceeded
     case githubAPIInvalidResponse(URLResponse)
     case githubLicenseJsonCannotBeDecoded(url: URL, json: String?, error: Error)
     case githubLicenseCannotBeDownloaded(URL)

--- a/Sources/SwiftPackageAcknowledgement/Commands/GeneratePlist.swift
+++ b/Sources/SwiftPackageAcknowledgement/Commands/GeneratePlist.swift
@@ -50,8 +50,15 @@ struct GeneratePlist: ParsableCommand {
             .sinkBlockingAndExit(
                 receiveCompletion: { completion in
                     switch completion {
-                    case let .failure(error): print("An error has occurred: \(error)")
-                    case .finished:           print("Done!")
+                    case let .failure(error):
+                        print("\n💥 An error has occurred: \(error)")
+                        if case .githubAPIBudgetExceeded = error {
+                            print("Github API has a limit of 60 requests per hour when you don't use a Developer Token.")
+                            print("Please consider going to https://github.com/settings/developers, creating an OAuth App and " +
+                                  "providing Client ID and Client Secret Token in the script call.")
+                        }
+                    case .finished:
+                        print("\n✅ Done!")
                     }
                 },
                 receiveValue: { _ in }

--- a/Tests/SwiftPackageAcknowledgementTests/BridgeTests.swift
+++ b/Tests/SwiftPackageAcknowledgementTests/BridgeTests.swift
@@ -16,6 +16,21 @@ class BridgeTests: XCTestCase {
                 package: "Commander",
                 repositoryURL: URL(string: "https://github.com/kylef/Commander")!,
                 state: .init()
+            ),
+            .init(
+                package: "SwiftPackageAcknowledgement",
+                repositoryURL: URL(string: "http://github.com/teufelaudio/SwiftPackageAcknowledgement")!,
+                state: .init()
+            ),
+            .init(
+                package: "FoundationExtensions",
+                repositoryURL: URL(string: "https://www.github.com/teufelaudio/FoundationExtensions")!,
+                state: .init()
+            ),
+            .init(
+                package: "NetworkExtensions",
+                repositoryURL: URL(string: "git@github.com:teufelaudio/NetworkExtensions.git")!,
+                state: .init()
             )
         ]
         let content = ResolvedPackageContent(
@@ -28,6 +43,8 @@ class BridgeTests: XCTestCase {
         
         // assert
         let repositories = packageRepositories.map(\.repository)
+        XCTAssertEqual(repositories.count, 5)
+        
         let acknowListRepo = repositories[0]
         XCTAssertEqual(acknowListRepo.name, "AcknowList")
         XCTAssertEqual(acknowListRepo.owner, "vtourraine")
@@ -35,5 +52,17 @@ class BridgeTests: XCTestCase {
         let commanderRepo = repositories[1]
         XCTAssertEqual(commanderRepo.name, "Commander")
         XCTAssertEqual(commanderRepo.owner, "kylef")
+
+        let spmAckRepo = repositories[2]
+        XCTAssertEqual(spmAckRepo.name, "SwiftPackageAcknowledgement")
+        XCTAssertEqual(spmAckRepo.owner, "teufelaudio")
+
+        let foundationExtRepo = repositories[3]
+        XCTAssertEqual(foundationExtRepo.name, "FoundationExtensions")
+        XCTAssertEqual(foundationExtRepo.owner, "teufelaudio")
+
+        let networkExtRepo = repositories[4]
+        XCTAssertEqual(networkExtRepo.name, "NetworkExtensions")
+        XCTAssertEqual(networkExtRepo.owner, "teufelaudio")
     }
 }


### PR DESCRIPTION
**1st issue: SSH repos**
You can configure SPM to refer to a repository in a SSH fashion, with URLs such as `git@github.com:SwiftRex/SwiftRex.git` instead of `https://github.com/SwiftRex/SwiftRex.git`. Now this script is able to parse this type as well.

The solution is a simple string replacement/split, alternatively we could use Regex (god helps us), functional parsers or more complex approaches. Probably this is not the most elegant but it's gonna work and it's easy to understand and maintain, please share your thoughts.

**2nd issue: repos with no LICENSE**
A repository may not have LICENSE file (HTTP Response 404), which means we can't add it to our third-party licenses screen. However, this should not be a blocker, because a repository without license is not legally requiring you to add it to your notices.

Such repo now will generate a warning, instead of blocking the whole process. This is useful for 1st party repositories as well, when you don't necessarily need a License to yourself. For other errors, we continue to fail with hard error (stop the process). One example of that is when the Github API budget is exceeded (HTTP Response 403), for which we now have a better error with proper instructions.