### PR TITLE
Ensure we are using the `exactItem` requirement for all packages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/teufelaudio/FoundationExtensions",
         "state": {
           "branch": null,
-          "revision": "aef679bde907365943fcc8bb5ba7a03e09ec48e3",
-          "version": "0.1.12"
+          "revision": "f6edccfb2dd08b74aa5e6b0bcb2da6b46430ac33",
+          "version": "0.1.6"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
         ])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.2"),
-        .package(url: "https://github.com/teufelaudio/FoundationExtensions", from: "0.1.6")
+        .package(url: "https://github.com/apple/swift-argument-parser", .exactItem(.init(1, 0, 2))),
+        .package(url: "https://github.com/teufelaudio/FoundationExtensions", .exactItem(.init(0, 1, 6)))
     ],
     targets: [
         .target(


### PR DESCRIPTION
We are using `SwiftPackageAcknowledgement` from Xcode, and each time the project was opened it was updating to the latest version of the `FoundationExtensions` package dependency, causing an error when resolving the packages:

```
xcodebuild: error: Could not resolve package dependencies:
  product 'FoundationExtensionsStatic' required by package 'swiftpackageacknowledgement' target 'SwiftPackageAcknowledgement' not found in package 'FoundationExtensions'.
```

Forcing an exact version ensures that the version being used is the one used while testing.