### PR TITLE
Fix SPM error when updating to latest FoundationExtensions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/teufelaudio/FoundationExtensions",
         "state": {
           "branch": null,
-          "revision": "aef679bde907365943fcc8bb5ba7a03e09ec48e3",
-          "version": "0.1.12"
+          "revision": "6b9bd39109a1634112c325aa2e4a6a63d58a6254",
+          "version": "0.5.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,13 +12,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.2"),
-        .package(url: "https://github.com/teufelaudio/FoundationExtensions", from: "0.1.6")
+        .package(url: "https://github.com/teufelaudio/FoundationExtensions", from: "0.5.1")
     ],
     targets: [
         .target(
             name: "Helper",
             dependencies: [
-                .product(name: "FoundationExtensionsStatic", package: "FoundationExtensions")
+                .product(name: "FoundationExtensions", package: "FoundationExtensions")
             ]
         ),
         .target(
@@ -27,14 +27,14 @@ let package = Package(
                 "Helper",
                 "Models",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                .product(name: "FoundationExtensionsStatic", package: "FoundationExtensions")
+                .product(name: "FoundationExtensions", package: "FoundationExtensions")
             ]
         ),
         .target(
             name: "Models",
             dependencies: [
                 "Helper",
-                .product(name: "FoundationExtensionsStatic", package: "FoundationExtensions")
+                .product(name: "FoundationExtensions", package: "FoundationExtensions")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Caused by renaming the static FoundationExtensions target without adjusting this package.