### PR TITLE
Update 'flatMapPublisher' to 'flatMapLatestPublisher'

### DIFF
--- a/Sources/SwiftPackageAcknowledgement/Commands/GeneratePlist.swift
+++ b/Sources/SwiftPackageAcknowledgement/Commands/GeneratePlist.swift
@@ -30,18 +30,18 @@ struct GeneratePlist: ParsableCommand {
             .mapResult { $0.ignoring(packages: (ignore ?? "").components(separatedBy: ",")) }
             .mapResult(extractPackageGitHubRepositories)
             .mapValue(\.promise)
-            .flatMapPublisher { packageRepositories in
+            .flatMapLatestPublisher { packageRepositories in
                 fetchGithubLicenses(
                     packageRepositories: packageRepositories,
                     githubClientID: self.gitClientID,
                     githubClientSecret: self.gitSecret
                 ).contramapEnvironment(\World.urlSession, \World.githubJsonDecoder)
             }
-            .flatMapPublisher { (packageLicenses: [PackageLicense]) in
+            .flatMapLatestPublisher { (packageLicenses: [PackageLicense]) in
                 cocoaPodsModel(packageLicenses: packageLicenses)
                     .contramapEnvironment(\World.urlSession)
             }
-            .flatMapPublisher { cocoaPods in
+            .flatMapLatestPublisher { cocoaPods in
                 saveToPList(cocoaPods: cocoaPods, path: self.outputFile)
                     .mapValue(\.promise)
                     .contramapEnvironment(\World.fileSave, \World.cocoaPodsEncoder)


### PR DESCRIPTION
It seemed that bumping the [teufelaudio/FoundationExtensions](https://github.com/teufelaudio/FoundationExtensions) version in the [PR](https://github.com/teufelaudio/SwiftPackageAcknowledgement/pull/12) broke the `flatMapPublisher`.

Based on this [commit](https://github.com/teufelaudio/FoundationExtensions/commit/21010b462f809af0c128983d01df14e9dddfd8fa), the `flatMapPublisher` has been renamed to `flatMapLatestPublisher`.